### PR TITLE
Falcon40b ctx size fixes

### DIFF
--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -494,6 +494,12 @@ extern "C" {
             int64_t ne2,
             int64_t ne3);
 
+    // Size overestimates.
+    GGML_API size_t ggml_sizeof_tensor_1d(enum ggml_type type, int64_t ne0);
+    GGML_API size_t ggml_sizeof_tensor_2d(enum ggml_type type, int64_t ne0, int64_t ne1);
+    GGML_API size_t ggml_sizeof_tensor_3d(enum ggml_type type, int64_t ne0, int64_t ne1, int64_t ne2);
+    GGML_API size_t ggml_sizeof_tensor_4d(enum ggml_type type, int64_t ne0, int64_t ne1, int64_t ne2, int64_t ne3);
+
     GGML_API struct ggml_tensor * ggml_new_i32(struct ggml_context * ctx, int32_t value);
     GGML_API struct ggml_tensor * ggml_new_f32(struct ggml_context * ctx, float value);
 

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -4059,6 +4059,36 @@ void ggml_scratch_load(struct ggml_context * ctx) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+size_t ggml_sizeof_tensor_data_impl(enum ggml_type type, int n_dims, const int64_t* ne) {
+    size_t size_needed = 0;
+    size_needed += GGML_TYPE_SIZE[type]*(ne[0]/GGML_BLCK_SIZE[type]);
+    for (int i = 1; i < n_dims; i++) {
+        size_needed *= ne[i];
+    }
+    // align to GGML_MEM_ALIGN
+    size_needed = ((size_needed + GGML_MEM_ALIGN - 1)/GGML_MEM_ALIGN)*GGML_MEM_ALIGN;
+    return size_needed;
+}
+
+size_t ggml_sizeof_tensor_1d(enum ggml_type type, int64_t ne0) {
+    return ggml_tensor_overhead() + ggml_sizeof_tensor_data_impl(type, 1, &ne0);
+}
+
+size_t ggml_sizeof_tensor_2d(enum ggml_type type, int64_t ne0, int64_t ne1) {
+    auto ne = {ne0, ne1};
+    return ggml_tensor_overhead() + ggml_sizeof_tensor_data_impl(type, 2, &ne);
+}
+
+size_t ggml_sizeof_tensor_3d(enum ggml_type type, int64_t ne0, int64_t ne1, int64_t ne2) {
+    auto ne = {ne0, ne1, ne2};
+    return ggml_tensor_overhead() + ggml_sizeof_tensor_data_impl(type, 3, &ne);
+}
+
+size_t ggml_sizeof_tensor_4d(enum ggml_type type, int64_t ne0, int64_t ne1, int64_t ne2, int64_t ne3) {
+    auto ne = {ne0, ne1, ne2, ne3};
+    return ggml_tensor_overhead() + ggml_sizeof_tensor_data_impl(type, 4, &ne);
+}
+
 struct ggml_tensor * ggml_new_tensor_impl(
         struct ggml_context * ctx,
         enum   ggml_type type,
@@ -4075,12 +4105,7 @@ struct ggml_tensor * ggml_new_tensor_impl(
     size_t size_needed = 0;
 
     if (data == NULL && !ctx->no_alloc) {
-        size_needed += GGML_TYPE_SIZE[type]*(ne[0]/GGML_BLCK_SIZE[type]);
-        for (int i = 1; i < n_dims; i++) {
-            size_needed *= ne[i];
-        }
-        // align to GGML_MEM_ALIGN
-        size_needed = ((size_needed + GGML_MEM_ALIGN - 1)/GGML_MEM_ALIGN)*GGML_MEM_ALIGN;
+        size_needed += ggml_sizeof_tensor_data_impl(type, n_dims, ne);
     }
 
     char * const mem_buffer = ctx->mem_buffer;


### PR DESCRIPTION
Context: https://github.com/ggerganov/ggml/pull/231

Tested falcon-{7,40}b-instruct with all flavours of quantization or lack thereof (q4_0 q4_1 q5_0 q5_1 q8_0 f16), see [script](https://gist.github.com/ochafik/065465d78ff066a6efc7a6e1f2b344f7).

No regression from this PR / no crash anymore ~~but incidentally found out 7b q8_0 only produces garbage~~ (**edit**: can't repro any issue after carefully reconverting everything, @jploski good to merge afaict ✌️)